### PR TITLE
Add non-interactive to certbot command. Bump version to 0.1.3

### DIFF
--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -26,7 +26,7 @@
       mode: a+x
 
   - name: Run certbot
-    command: "{{certbot_dir}}/certbot-auto certonly --email {{letsencrypt_email}} --domains {{([server_name] + server_aliases) | join(',')}} --apache --agree-tos"
+    command: "{{certbot_dir}}/certbot-auto certonly --email {{letsencrypt_email}} --domains {{([server_name] + server_aliases) | join(',')}} --apache --agree-tos --non-interactive"
     args:
       creates: /etc/letsencrypt/live/{{server_name}}/cert.pem
 

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Small change but fixes a bug where certbot would hang waiting for user
input if you already had a cert for a domain but tried getting a new
cert with both the old and a new domain.

This happens when, for example, production is setup with a temporary url
and then the real url is added later. A new cert needs to be fetched but
without --non-interactive certbot hangs waiting for confirmation that you
want to replace the old cert (with only one domain) with the new cert
with both the old domain and the new domain.