### PR TITLE
Set letsencrypt renew task to run at 4am

### DIFF
--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -88,6 +88,5 @@
     cron:
       name: Auto-renew SSL
       job: "{{certbot_dir}}/certbot-auto renew --quiet --no-self-upgrade"
-      minute: 30
-      hour: "0,12"
+      hour: 4
       state: present


### PR DESCRIPTION
Instead of midnight and noon
https://github.com/tenforwardconsulting/subspace/issues/6