### PR TITLE
Add missing sudos

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -36,6 +36,7 @@
           group=root
           mode=0644
           backup=yes
+    sudo: true
     notify:
       - update timezone
 

--- a/ansible/roles/delayed_job/tasks/main.yml
+++ b/ansible/roles/delayed_job/tasks/main.yml
@@ -3,11 +3,13 @@
     apt:
       name: monit
       state: present
+    sudo: true
 
   - name: Install delayed_job monit script
     template:
       src: delayed-job-monit-rc
       dest: /etc/monit/conf.d/delayed_job_{{project_name}}_{{rails_env}}
+    sudo: true
     notify: monit reload
 
   - name: Copy sudoers file so that deploy can restart services without entering password.
@@ -27,8 +29,10 @@
     file:
       path: /etc/init/delayed-job.conf
       state: absent
+    sudo: true
 
   - name: Remove old monit files
     file:
       path: /etc/monit/conf.d/delayed_job
       state: absent
+    sudo: true

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,20 +1,27 @@
 - name: Install nginx
   apt: pkg=nginx state=latest
+  sudo: true
 
 - name: Remove the default app
   command: rm -rf /etc/nginx/sites-enabled/default
+  sudo: true
 
 - name: Remove the app's config, if exists
   command: rm -rf /etc/nginx/sites-enabled/default
+  sudo: true
 
 - name: Remove the app's symlink, if exists
   command: rm -rf /etc/nginx/sites-enabled/{{project_name}}
+  sudo: true
 
 - name: Configure nginx for the app
   template: src=nginx-project dest=/etc/nginx/sites-available/{{project_name}} group=www-data owner=www-data force=yes
+  sudo: true
 
 - name: Enable the app
   command: ln -s /etc/nginx/sites-available/{{project_name}} /etc/nginx/sites-enabled/{{project_name}}
+  sudo: true
 
 - name: Restart nginx
   action: service name=nginx state=restarted
+  sudo: true

--- a/ansible/roles/papertrail/tasks/main.yml
+++ b/ansible/roles/papertrail/tasks/main.yml
@@ -1,12 +1,27 @@
 ---
   - name: Install remote_syslog from papertrail
     command: wget -O /tmp/remote_syslog.tar.gz https://github.com/papertrail/remote_syslog2/releases/download/v0.13/remote_syslog_linux_amd64.tar.gz  creates=/usr/bin/remote_syslog
+
   - command: tar xzf /tmp/remote_syslog.tar.gz chdir=/tmp/ creates=/usr/bin/remote_syslog
+
   - command: mv /tmp/remote_syslog/remote_syslog /usr/bin/remote_syslog creates=/usr/bin/remote_syslog
+    sudo: true
+
   - file: path=/usr/bin/remote_syslog owner=root group=root mode=0755
+    sudo: true
+
   - command: wget -O /etc/init.d/remote_syslog https://raw.githubusercontent.com/papertrail/remote_syslog2/v0.13/examples/remote_syslog.init.d creates=/etc/init.d/remote_syslog
+    sudo: true
+
   - file: path=/etc/init.d/remote_syslog owner=root group=root mode=0755
+    sudo: true
+
   - file: path=/tmp/remote_syslog/ state=absent
+
   - file: path=/tmp/remote_syslog.tar.gz state=absent
+
   - service: name=remote_syslog state=restarted enabled=yes
+    sudo: true
+
   - template: src=log_files.yml dest=/etc/log_files.yml owner=root group=root mode=0644
+    sudo: true

--- a/ansible/roles/ruby-common/tasks/main.yml
+++ b/ansible/roles/ruby-common/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Update APT cache
   apt: update_cache=yes
+  sudo: true
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Retrieve the number of cores that are available for compilation
@@ -9,6 +10,7 @@
 
 - name: Install APT prerequisite packages that are necessary to compile applications and gems with native extensions
   apt: pkg={{ item }}
+  sudo: true
   with_items:
     - autoconf
     - build-essential
@@ -16,18 +18,21 @@
 
 - name: Install yum prerequisite packages that are necessary to compile applications and gems with native extensions
   yum: name="{{ item }}"
+  sudo: true
   with_items:
     - autoconf
     - "@Developer tools"
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'Amazon'
 
 - name: Install APT Ruby dependencies
+  sudo: true
   apt: pkg={{ item }}
        state=present
   with_items: ruby_apt_dependencies
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Install yum Ruby dependencies
+  sudo: true
   yum: name={{ item }}
   with_items: ruby_yum_dependencies
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'Amazon'
@@ -36,6 +41,7 @@
   get_url: url={{ ruby_download_location }}
            dest=/usr/local/src/
            sha256sum={{ ruby_checksum }}
+  sudo: true
 
 - name: Generate the Ruby installation script
   template: src=install-ruby.j2
@@ -43,10 +49,12 @@
             owner=root
             group=root
             mode=700
+  sudo: true
 
 - name: Run the Ruby installation script
   command: /usr/local/src/install-ruby.sh
            creates={{ ruby_location }}/bin/ruby
+  sudo: true
 
 - name: Generate the script that allows you to easily run Rake tasks with the correct RAILS_ENV environment variable, and the wrapper script that contains GC settings
   template: src={{ item }}.j2
@@ -54,6 +62,7 @@
             owner=root
             group=root
             mode=755
+  sudo: true
   with_items:
     - rake-env
     - ruby-gc-wrapper
@@ -61,9 +70,11 @@
 - name: Install Bundler
   command: "{{ ruby_location }}/bin/gem install bundler {{ ruby_bundler_flags }}
             creates={{ ruby_location }}/bin/bundle"
+  sudo: true
 
 - name: Make Ruby symlinks
   file: path=/usr/local/bin/{{ item }}
         src={{ ruby_location }}/bin/{{ item }}
         state=link
+  sudo: true
   with_items: ruby_symlinks


### PR DESCRIPTION
We don't usually need them since our playbooks are run with `sudo: yes`,
but it's probably more correct to apply sudo only where it's needed.

Alex found these when he was doing VB stuff: https://github.com/tenforwardconsulting/ansible/commit/01252e96696a836561400f87d32bc795fd776a81. I just added them to subspace.