### PR TITLE
Fix postgresql role for postgresql version 9.5 and greater

### DIFF
--- a/ansible/roles/zenoamaro.postgresql/templates/postgresql.conf
+++ b/ansible/roles/zenoamaro.postgresql/templates/postgresql.conf
@@ -51,7 +51,9 @@ bonjour_name = '{{postgresql_bonjour_name}}' # defaults to the computer name
 authentication_timeout  = {{postgresql_authentication_timeout}}
 ssl                     = {{'on' if postgresql_ssl else 'off'}}
 ssl_ciphers             = '{{postgresql_ssl_ciphers|join(':')}}'
+{% if postgresql_version < 9.5 %}
 ssl_renegotiation_limit = {{postgresql_ssl_renegotiation_limit}}
+{% endif %}
 ssl_cert_file           = '{{postgresql_ssl_cert_file}}'
 ssl_key_file            = '{{postgresql_ssl_key_file}}'
 ssl_ca_file             = '{{postgresql_ssl_ca_file}}'
@@ -152,7 +154,9 @@ wal_writer_delay = {{postgresql_wal_writer_delay}} # 1-10000 milliseconds
 commit_delay     = {{postgresql_commit_delay}} # range 0-100000, in microseconds
 commit_siblings  = {{postgresql_commit_siblings}} # range 1-1000
 
+{% if postgresql_version < 9.5 %}
 checkpoint_segments          = {{postgresql_checkpoint_segments}} # in logfile segments, min 1, 16MB each
+{% endif %}
 checkpoint_timeout           = {{postgresql_checkpoint_timeout}} # range 30s-1h
 checkpoint_completion_target = {{postgresql_checkpoint_completion_target}} # checkpoint target duration, 0.0 - 1.0
 checkpoint_warning           = {{postgresql_checkpoint_warning}} # 0 disables


### PR DESCRIPTION
See the "Migration to Version 9.5" notes here:
https://www.postgresql.org/docs/9.6/static/release-9-5.html

Notably are the removal of the checkpoint_segments option and the
ssl_renegotiation_limit configuration options.