### PR TITLE
Don't install yarn as part of rails role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
-* _nada_
+* bug fixes
+  * Don't have rails role install yarn -- it's not needed by default, and if the
+    project does need it, it should explicitly use the yarn role.
+
 
 ## 0.5.15 - 2018-06-15
 

--- a/ansible/roles/rails/tasks/main.yml
+++ b/ansible/roles/rails/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-  - name: Add yarn apt key
-    apt_key:
-      url: https://dl.yarnpkg.com/debian/pubkey.gpg
-      state: present
-
-  - name: Add yarn apt repo
-    apt_repository:
-      repo: deb https://dl.yarnpkg.com/debian/ stable main
-      state: present
-
   - name: Install rails apt dependencies
     apt:
       name: "{{item}}"
@@ -22,7 +12,6 @@
       - libxslt-dev
       - nodejs
       - zlib1g-dev
-      - yarn
     become: true
 
   - name: Create /u/apps/{{project_name}}/shared/config


### PR DESCRIPTION
It's not actually required (although rails will give you a warning
during asset precomp). There is now a separate yarn role for when it is
actually needed.