### PR TITLE
Support terminal color prompt highlighting - blue for dev, yellow for qa, red for production.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
-* _nada_
+* enhancements
+  * Add a terminal environment prompt background color to the `common` role, so you know what environment you're `ssh`'d into.
 
 ## 1.0.6 - 2018-11-12
 

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -2,6 +2,21 @@
   - name: Test connection
     ping:
 
+  - name: Create terminal color file and make it executable
+    file:
+      path: "/etc/profile.d/termcolor.sh"
+      state: touch
+      mode: a+x
+    become: true
+  
+  - name: Set terminal color
+    vars:
+      terminal_env_playbook: "{{terminal_env | default('not provided', true) }}" 
+    template: 
+      src: terminalcolor
+      dest: "/etc/profile.d/termcolor.sh"
+    become: true
+
   - name: Set MOTD
     template:
       src: motd

--- a/ansible/roles/common/templates/motd
+++ b/ansible/roles/common/templates/motd
@@ -8,6 +8,6 @@ This server brought to you by:
 ~~~ https://github.com/tenforwardconsulting/subspace ~~~
 
 If you need to make configuration changes to the server, please modify the
-config/provision directory in the app or risk the changes dissapearing.
+config/provision directory in the app or risk the changes disappearing.
 
 Last subspace run: {{ansible_date_time.iso8601}}

--- a/ansible/roles/common/templates/terminalcolor
+++ b/ansible/roles/common/templates/terminalcolor
@@ -1,0 +1,25 @@
+{% if terminal_env_playbook == 'production'  %}
+export PROMPT_COMMAND='export PS1="\[\e[0;37m\]\[\e[1;41m\][\u@\h \W]\$ \[\e[0m\]"'
+
+#Write a big red rectangle to warn when you're logged into production
+echo -e '\e[0;41m\e[37m' #Set terminal colors
+for run in {1..4}
+do
+    echo "     !!!      PRODUCTION     !!!"
+done
+echo -e '\e[0m' #Reset terminal color to default
+echo ''
+
+{% elif terminal_env_playbook == 'development' or terminal_env_playbook == 'dev'  %}
+export PROMPT_COMMAND='export PS1="\[\e[0;37m\]\[\e[1;44m\][\u@\h \W]\$ \[\e[0m\]"'
+{% elif terminal_env_playbook == 'qa' %}
+export PROMPT_COMMAND='export PS1="\[\e[0;37m\]\[\e[1;43m\][\u@\h \W]\$ \[\e[0m\]"'
+{% else %}
+echo ''
+echo -e $'
+    No terminal environment color defined. 
+    Define variable \e[0;43m\e[37m terminal_env \e[0m in your vars. 
+    Acceptable values are \'development\', \'dev\', \'qa\', or \'production\'.
+    '
+echo ''
+{% endif %}


### PR DESCRIPTION
To test:

1. Clone local copy of subspace
2. Pick a local repo that uses subspace
3. Edit your Gemfile in that repo. Update the gem source to point to your local subspace
` gem 'subspace', path: '/Users/fred/subspace'`
4. Update your /config/provision/group_vars for an environment and add variable `terminal_env`
5. Test different values of this variable:

- Variable not defined
- Empty string
- dev
- development
- qa
- production
- some other string

(dev | development) should have a blue terminal prompt
qa should have a yellow terminal prompt
production should have a red terminal prompt with a big warning page
any other value should display a message telling you to set the terminal_env value.