### PR TITLE
Groups delayed_job count queries by queue

### DIFF
--- a/ansible/roles/collectd/templates/delayed_job_postgres.conf
+++ b/ansible/roles/collectd/templates/delayed_job_postgres.conf
@@ -1,11 +1,12 @@
 LoadPlugin postgresql
 <Plugin postgresql>
   <Query dj_count>
-    Statement "SELECT count(*) as count FROM delayed_jobs"
+    Statement "SELECT count(*) as count, queue FROM delayed_jobs GROUP BY queue"
     <Result>
       Type gauge
       InstancePrefix "dj_count"
-      ValuesFrom count
+      InstancesFrom "queue"
+      ValuesFrom "count"
     </Result>
   </Query>
 


### PR DESCRIPTION
With this change, you can build graphs that break out delayed_job counts by queue, rather than seeing them all globbed together in one giant number.

When applied, you can create grafana dashboards such as...

![dj-grafana](https://user-images.githubusercontent.com/102357/53930638-a53bc180-4057-11e9-991b-a7d6d8e257ba.png)
