### PR TITLE
Add letsencrypt_dns role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
   * Not working on OSX - macs don't read from /etc/profile.d/
   * Stops showing color if you `sudo su`
 
+## 2.0.4
+  * Add letsencrypt_dns role for doing DNS validation vs HTTP validation
+
 ## 2.0.3
   * Fix bundler / gem version installation on new/vanilla servers
 

--- a/ansible/roles/common/templates/motd
+++ b/ansible/roles/common/templates/motd
@@ -4,7 +4,7 @@ This server brought to you by:
 \___ \| | | | '_ \___ \| '_ \ / _` |/ __/ _ \
  ___) | |_| | |_) |__) | |_) | (_| | (_|  __/
 |____/ \__,_|_.__/____/| .__/ \__,_|\___\___|
-                       |_|             v2.0.3
+                       |_|             v2.0.4
 ~~~ https://github.com/tenforwardconsulting/subspace ~~~
 
 If you need to make configuration changes to the server, please modify the

--- a/ansible/roles/letsencrypt_dns/defaults/main.yml
+++ b/ansible/roles/letsencrypt_dns/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+  nginx_ssl_config: |
+    ssl_certificate /etc/letsencrypt/live/{{server_name}}/fullchain.crt;
+    ssl_certificate_key /etc/letsencrypt/live/{{server_name}}/privkey.pem;

--- a/ansible/roles/letsencrypt_dns/tasks/main.yml
+++ b/ansible/roles/letsencrypt_dns/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Update repositories cache and install "foo" package
+- name: Update repositories cache and install pip and setuptools package
   apt:
     name: [python-pip, python-setuptools]
     update_cache: yes

--- a/ansible/roles/letsencrypt_dns/tasks/main.yml
+++ b/ansible/roles/letsencrypt_dns/tasks/main.yml
@@ -1,0 +1,133 @@
+- name: Update repositories cache and install "foo" package
+  apt:
+    name: [python-pip, python-setuptools]
+    update_cache: yes
+
+- pip:
+    name: [pyopenssl, boto]
+  tags:
+    - cert
+
+- name: Creates private key directory
+  file:
+    path: "/etc/letsencrypt/live/{{ server_name }}"
+    state: directory
+  tags:
+    - cert
+
+- name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
+  openssl_privatekey:
+    path: "/etc/letsencrypt/live/{{ server_name }}/privkey.pem"
+  register: privkey
+  tags:
+    - cert
+
+- name: Generate an OpenSSL account key with the default values (4096 bits, RSA)
+  openssl_privatekey:
+    path: "/etc/letsencrypt/live/{{ server_name }}/account.pem"
+  tags:
+    - cert
+
+- name: Generate an OpenSSL Certificate Signing Request
+  openssl_csr:
+    path: "/etc/letsencrypt/live/{{ server_name }}/server.csr"
+    privatekey_path: "/etc/letsencrypt/live/{{ server_name }}/privkey.pem"
+    country_name: US
+    email_address: "{{ letsencrypt_email }}"
+    subject_alt_name: "{{ item.value | map('regex_replace', '^', 'DNS:') | list }}"
+  when: privkey is changed
+  register: csr
+  with_dict:
+    dns_server:
+    - "{{ server_name }}"
+    - "*.{{ server_name }}"
+  tags:
+    - cert
+
+- name: Create a challenge using an account key from a variable.
+  acme_certificate:
+    acme_version: 2
+    account_key_src: "/etc/letsencrypt/live/{{ server_name }}/account.pem"
+    csr: "/etc/letsencrypt/live/{{ server_name }}/server.csr"
+    cert: "/etc/letsencrypt/live/{{ server_name }}/server.crt"
+    fullchain: "/etc/letsencrypt/live/{{ server_name }}/fullchain.crt"
+    chain: "/etc/letsencrypt/live/{{ server_name }}/intermediate.crt"
+    challenge: dns-01
+    acme_directory: https://acme-v02.api.letsencrypt.org/directory
+    terms_agreed: yes
+    remaining_days: 60
+  when: csr is changed
+  register: le_challenge
+  tags:
+    - cert
+
+- name: Install txt record on route53
+  route53:
+    zone: "{{ route53_zone }}"
+    type: TXT
+    ttl: 60
+    state: present
+    wait: yes
+    record: "{{ item.key }}"
+    value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
+    aws_access_key: "{{ AWS_ACCESS_KEY_ID }}"
+    aws_secret_key: "{{ AWS_SECRET_ACCESS_KEY }}"
+    overwrite: yes
+  loop: "{{ le_challenge.challenge_data_dns | default({}) | dict2items }}"
+  tags:
+    - cert
+
+- name: Flush dns cache
+  become: true
+  command: "systemd-resolve --flush-caches"
+  when: le_challenge is changed
+  tags:
+    - cert
+
+- name: "Wait for DNS"
+  when: le_challenge is changed
+  pause:
+    minutes: 2
+  tags:
+    - cert
+
+- name: Let the challenge be validated and retrieve the cert and intermediate certificate
+  acme_certificate:
+    acme_version: 2
+    account_key_src: "/etc/letsencrypt/live/{{ server_name }}/account.pem"
+    csr: "/etc/letsencrypt/live/{{ server_name }}/server.csr"
+    cert: "/etc/letsencrypt/live/{{ server_name }}/server.crt"
+    fullchain: "/etc/letsencrypt/live/{{ server_name }}/fullchain.crt"
+    chain: "/etc/letsencrypt/live/{{ server_name }}/intermediate.crt"
+    challenge: dns-01
+    acme_directory: https://acme-v02.api.letsencrypt.org/directory
+    remaining_days: 60
+    terms_agreed: yes
+    data: "{{ le_challenge }}"
+  when: le_challenge is changed
+  tags:
+    - cert
+
+- name: Delete txt record on route53
+  route53:
+    zone: "{{ route53_zone }}"
+    type: TXT
+    ttl: 60
+    state: absent
+    wait: yes
+    record: "{{ item.key }}"
+    value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
+    aws_access_key: "{{ AWS_ACCESS_KEY_ID }}"
+    aws_secret_key: "{{ AWS_SECRET_ACCESS_KEY }}"
+    overwrite: yes
+  loop: "{{ le_challenge.challenge_data_dns | default({}) | dict2items }}"
+  tags:
+    - cert
+
+- name: restart webserver
+  debug: msg="restart webserver"
+  notify: restart webserver
+  changed_when: true
+  when: le_challenge is changed
+  tags:
+    - cert

--- a/ansible/roles/nginx/handlers/main.yml
+++ b/ansible/roles/nginx/handlers/main.yml
@@ -6,3 +6,7 @@
 - name: start webserver
   service: name=nginx state=started
   become: true
+
+- name: restart webserver
+  service: name=nginx state=restarted
+  become: true

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "2.0.3"
+  VERSION = "2.0.4"
 end


### PR DESCRIPTION
Currently, the letsencrypt role uses HTTP validation, this has 2 problems:

1. It can't handle wildcards
2. It can't validate servers that are private

This PR adds a new role `letsencrypt_dns` to validate via DNS to solve the above problems. It also uses the official ansible module `acme_certificate`

Notes/Todos:

- This assumes you're using Route53
- It doesn't include anything to automatically renew the certificate via cron like the other role does