### PR TITLE
Fixes #120 - Checking for "true" string on ssl_force_redirect; adds config option for default_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project attempts to follow [semantic versioning](https://semver.org/)
   * Not working on OSX - macs don't read from /etc/profile.d/
   * Stops showing color if you `sudo su`
 
+## 2.1.0
+  * Add config option for default_server directive in nginx.
+  * Fixed bug in SSL redirect from 2.0.1
+  
 ## 2.0.4
   * Add letsencrypt_dns role for doing DNS validation vs HTTP validation
 

--- a/ansible/roles/nginx-rails/defaults/main.yml
+++ b/ansible/roles/nginx-rails/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
   client_max_body_size: 4G
   ssl_force_redirect: true
+  default_server: true

--- a/ansible/roles/nginx-rails/templates/nginx-project
+++ b/ansible/roles/nginx-rails/templates/nginx-project
@@ -2,7 +2,7 @@
 {% include "_upstream.conf" %}
 
 server {
-  listen 80;
+  listen 80 {{ 'default_server' if default_server == True else ''}};
   server_name {{server_name}} {{server_aliases | join(" ")}};
 
   {% include "_rails.conf" %}

--- a/ansible/roles/nginx-rails/templates/nginx-project-ssl
+++ b/ansible/roles/nginx-rails/templates/nginx-project-ssl
@@ -6,7 +6,7 @@ server {
   listen [::]:80 default_server;
   server_name {{server_name}} {{server_aliases | join(" ")}};
 
-  {% if ssl_force_redirect == "true" %}
+  {% if (ssl_force_redirect == True) or (ssl_force_redirect == "true") %}
   return 301 https://$host$request_uri;
   {% else %}
   {% include "_rails.conf" %}

--- a/ansible/roles/nginx-rails/templates/nginx-project-ssl
+++ b/ansible/roles/nginx-rails/templates/nginx-project-ssl
@@ -2,8 +2,8 @@
 {% include "_upstream.conf" %}
 
 server {
-  listen 80 default_server;
-  listen [::]:80 default_server;
+  listen 80 {{ 'default_server' if default_server == True else ''}};
+  listen [::]:80 {{ 'default_server' if default_server == True else ''}};
   server_name {{server_name}} {{server_aliases | join(" ")}};
 
   {% if (ssl_force_redirect == True) or (ssl_force_redirect == "true") %}

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "2.0.4"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
See issue #120 
We hardcoded the string "true" in there, so actual boolean True values are falsey when compared to that string.

The PR fixes that bug but leaves the former string option for backward-compatibility.