### PR TITLE
Gather stats for Rails, Ruby, and Apt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
   * Not working on OSX - macs don't read from /etc/profile.d/
   * Stops showing color if you `sudo su`
 
+## 2.1.0
+  * Adds ability to gather Ruby, Rails, and apt details from servers and send to a stats collector
+  
 ## 2.0.4
   * Add letsencrypt_dns role for doing DNS validation vs HTTP validation
 

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -70,6 +70,8 @@
       path: /opt/subspace
       state: directory
     become: true
+    tags:
+      - upgrade
 
   - name: Save updates to /opt/subspace/updates.log
     lineinfile:
@@ -78,6 +80,8 @@
       insertafter: EOF
       create: yes
     become: true
+    tags:
+      - upgrade
 
   - name: apt-get upgrade
     apt: upgrade=full
@@ -91,6 +95,68 @@
     become: true
     tags:
       - upgrade
+
+  - name: Get os_upgrades stats
+    shell:
+      cmd: |
+        sed -n "/$(date '+%Y-%m')/,+2p" updates.log | # Groups of lines from the current month
+        grep 'packages' | # Only lines matching 'packages'
+        grep -P -o '(^\d+)' | #Extract the numbers at the beginning of the lines
+        awk '{s+=$1} END {print s}' # Sum all the lines
+    args:
+      chdir: /opt/subspace
+    register: stats_os_upgrades
+    when: send_stats == true and stats_url is defined and stats_api_key is defined
+    tags:
+      - stats
+  
+  - name: Send os_upgrades stats to URL
+    uri:
+      url: "{{stats_url}}"
+      method: POST
+      headers:
+        X-API-Version: 1
+        X-Client-Api-key: "{{stats_api_key}}"
+      body_format: json
+      body:
+        client_stat:
+          key: os_upgrades
+          value: "{{stats_os_upgrades.stdout}}"
+          hostname: "{{ansible_ssh_host}}"
+    when: send_stats == true and stats_url is defined and stats_api_key is defined
+    tags:
+      - stats
+
+  - name: Get os_security_upgrades stats
+    shell:
+      cmd: |
+        sed -n "/$(date '+%Y-%m')/,+2p" updates.log | # Groups of lines from the current month
+        grep 'security' | # Only lines matching 'security'
+        grep -P -o '(^\d+)' | #Extract the numbers at the beginning of the lines
+        awk '{s+=$1} END {print s}' # Sum all the lines
+    args:
+      chdir: /opt/subspace
+    register: stats_os_security_upgrades
+    when: send_stats == true and stats_url is defined and stats_api_key is defined
+    tags:
+      - stats
+  
+  - name: Send os_security_upgrades stats to URL
+    uri:
+      url: "{{stats_url}}"
+      method: POST
+      headers:
+        X-API-Version: 1
+        X-Client-Api-key: "{{stats_api_key}}"
+      body_format: json
+      body:
+        client_stat:
+          key: os_security_upgrades
+          value: "{{stats_os_security_upgrades.stdout}}"
+          hostname: "{{ansible_ssh_host}}"
+    when: send_stats == true and stats_url is defined and stats_api_key is defined
+    tags:
+      - stats
 
   - name: set timezone to America/Chicago
     timezone:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
   - name: Test connection
     ping:
+    tags:
+      - maintenance
 
   - name: Ensure /etc/profile.d/ exists
     file:
@@ -8,6 +10,8 @@
       owner: root
       state: directory
     become: yes
+    tags:
+      - maintenance
 
   - name: Set terminal color
     vars:
@@ -17,16 +21,22 @@
       dest: "/etc/profile.d/termcolor.sh"
       mode: a+x
     become: true
+    tags:
+      - maintenance
 
   - name: Set MOTD
     template:
       src: motd
       dest: /etc/motd
     become: true
+    tags:
+      - maintenance
 
   - name: Set hostname
     command: hostname {{hostname}}
     become: true
+    tags:
+      - maintenance
 
   - name: Set hostname in /etc/hosts
     lineinfile:
@@ -35,34 +45,44 @@
       state: present
       insertafter: "127.0.0.1 localhost"
     become: true
+    tags:
+      - maintenance
 
   - name: update /etc/hostname
     copy:
       content: "{{hostname}}"
       dest: /etc/hostname
     become: true
+    tags:
+      - maintenance
 
   - name: Set hostname for systemd
     hostname:
       name: "{{hostname}}"
     become: true
+    tags:
+      - maintenance
 
   - name: install aptitude
     apt:
       pkg: aptitude
       state: present
     become: true
+    tags:
+      - maintenance
 
   - name: apt-get update
     apt: update_cache=yes cache_valid_time=86400
     become: true
     tags:
       - upgrade
+      - maintenance
 
   - name: /usr/lib/update-notifier/apt-check --human-readable
     command: /usr/lib/update-notifier/apt-check --human-readable
     tags:
       - upgrade
+      - maintenance
     register: out
 
   - name: Creates /opt/subspace
@@ -71,6 +91,7 @@
       state: directory
     become: true
     tags:
+      - maintenance
       - upgrade
 
   - name: Save updates to /opt/subspace/updates.log
@@ -81,12 +102,14 @@
       create: yes
     become: true
     tags:
+      - maintenance
       - upgrade
 
   - name: apt-get upgrade
     apt: upgrade=full
     become: true
     tags:
+      - maintenance
       - upgrade
 
   - name: apt-get autoremove
@@ -94,6 +117,7 @@
       autoremove: true
     become: true
     tags:
+      - maintenance
       - upgrade
 
   - name: Get os_upgrades stats
@@ -108,6 +132,7 @@
     register: stats_os_upgrades
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:
+      - maintenance
       - stats
   
   - name: Send os_upgrades stats to URL
@@ -125,6 +150,7 @@
           hostname: "{{ansible_ssh_host}}"
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:
+      - maintenance
       - stats
 
   - name: Get os_security_upgrades stats
@@ -139,6 +165,7 @@
     register: stats_os_security_upgrades
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:
+      - maintenance
       - stats
   
   - name: Send os_security_upgrades stats to URL
@@ -156,11 +183,14 @@
           hostname: "{{ansible_ssh_host}}"
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:
+      - maintenance
       - stats
 
   - name: set timezone to America/Chicago
     timezone:
       name: America/Chicago
+    tags:
+      - maintenance
 
   - name: Add deploy user
     user:
@@ -169,6 +199,8 @@
       generate_ssh_key: yes
       shell: /bin/bash
     become: true
+    tags:
+      - maintenance
 
   - name: Add deploy user to adm group so it can view logs in /var/log
     user:
@@ -176,12 +208,16 @@
       append: yes
       groups: "adm"
     become: true
+    tags:
+      - maintenance
 
   - name: Add sudoers.d file so that deploy can restart services without entering password.
     copy:
       src: sudoers-service
       dest: /etc/sudoers.d/service
     become: true
+    tags:
+      - maintenance
 
   - name: Update authorized_keys for deploy user
     copy:
@@ -191,6 +227,7 @@
     become: true
     tags:
       - authorized_keys
+      - maintenance
 
   - name: Create directory to which to deploy
     file:
@@ -198,5 +235,7 @@
       owner: "{{deploy_user}}"
       state: directory
     become: true
+    tags:
+      - maintenance
 
   - import_tasks: swap.yml

--- a/ansible/roles/rails/tasks/main.yml
+++ b/ansible/roles/rails/tasks/main.yml
@@ -72,3 +72,29 @@
       owner: "{{deploy_user}}"
     tags:
       - appyml
+
+  - name: Grab Rails version
+    shell: bundle exec rails --version
+    args:
+      chdir: /u/apps/{{project_name}}/current
+    register: stats_rails_version
+    when: send_stats == true and stats_url is defined and stats_api_key is defined
+    tags:
+      - stats
+
+  - name: Send Rails stats to URL
+    uri:
+      url: "{{stats_url}}"
+      method: POST
+      headers:
+        X-API-Version: 1
+        X-Client-Api-key: "{{stats_api_key}}"
+      body_format: json
+      body:
+        client_stat:
+          key: rails_version
+          value: "{{stats_rails_version.stdout}}"
+          hostname: "{{ansible_ssh_host}}"
+    when: send_stats == true and stats_url is defined and stats_api_key is defined
+    tags:
+      - stats

--- a/ansible/roles/rails/tasks/main.yml
+++ b/ansible/roles/rails/tasks/main.yml
@@ -13,12 +13,15 @@
       - ffmpeg
     become: true
     when: ('Ubuntu' in ansible_distribution)
+    tags:
+      - maintenance
 
   - name: Install imagemagick
     apt:
       name: ['imagemagick', 'libmagickwand-dev']
     become: true
     tags:
+      - maintenance
       - imagemagick
     when: ('Ubuntu' in ansible_distribution)
 
@@ -30,6 +33,7 @@
       backrefs: yes
     become: true
     tags:
+      - maintenance
       - imagemagick
     when: ('Ubuntu' in ansible_distribution)
 
@@ -39,6 +43,8 @@
       state: directory
     become: true
     become_user: "{{deploy_user}}"
+    tags:
+      - maintenance
 
   - name: Create database.yml
     template:
@@ -80,6 +86,7 @@
     register: stats_rails_version
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:
+      - maintenance
       - stats
 
   - name: Send Rails stats to URL
@@ -97,4 +104,6 @@
           hostname: "{{ansible_ssh_host}}"
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:
+      - maintenance
       - stats
+

--- a/ansible/roles/ruby-common/tasks/main.yml
+++ b/ansible/roles/ruby-common/tasks/main.yml
@@ -106,6 +106,7 @@
   register: stats_ruby_version
   when: send_stats == true and stats_url is defined and stats_api_key is defined
   tags:
+    - maintenance
     - stats
 
 - name: Send Ruby stats to URL
@@ -123,4 +124,5 @@
         hostname: "{{ansible_ssh_host}}"
   when: send_stats == true and stats_url is defined and stats_api_key is defined
   tags:
+    - maintenance
     - stats

--- a/ansible/roles/ruby-common/tasks/main.yml
+++ b/ansible/roles/ruby-common/tasks/main.yml
@@ -100,3 +100,27 @@
         state=link
   become: true
   with_items: "{{ ruby_symlinks }}"
+
+- name: Grab Ruby version
+  shell: ruby --version
+  register: stats_ruby_version
+  when: send_stats == true and stats_url is defined and stats_api_key is defined
+  tags:
+    - stats
+
+- name: Send Ruby stats to URL
+  uri:
+    url: "{{stats_url}}"
+    method: POST
+    headers:
+      X-API-Version: 1
+      X-Client-Api-key: "{{stats_api_key}}"
+    body_format: json
+    body:
+      client_stat:
+        key: ruby_version
+        value: "{{stats_ruby_version.stdout}}"
+        hostname: "{{ansible_ssh_host}}"
+  when: send_stats == true and stats_url is defined and stats_api_key is defined
+  tags:
+    - stats

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "2.0.4"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Publishes stats to a waiting API when the tag "stats" runs.

`subspace provision production --tags=stats`

Edit vars like:
```
# Ansible vars for stats
stats_url: https://dev.tenforward.services/api/client_stats
send_stats: true
stats_api_key: 81356f1bb434545ac410eac910316ff91a
```