### PR TITLE
Fixed #125 remove invalid config parameter for versions < 10; and #127 for LetsEncrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project attempts to follow [semantic versioning](https://semver.org/)
   * Not working on OSX - macs don't read from /etc/profile.d/
   * Stops showing color if you `sudo su`
 
+## 2.1.2
+  * bug fixes
+    * PostgreSQL database server works for version > 10
+
 ## 2.1.1
   * bug fixes
     * Fix error when not setting send_stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 ## 2.1.2
   * bug fixes
     * PostgreSQL database server works for version > 10
+    * New LetsEncrypt/NGINX servers get the correct file from the certbot repo 
 
 ## 2.1.1
   * bug fixes

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -60,7 +60,7 @@
   - name: Update nginx default options
     when: "'nginx' in role_names"
     get_url:
-      url: https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-nginx.conf
+      url: https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/tls_configs/options-ssl-nginx.conf
       dest: /etc/letsencrypt/options-ssl-nginx.conf
 
   - name: Update apache default options

--- a/ansible/roles/zenoamaro.postgresql/templates/postgresql.conf
+++ b/ansible/roles/zenoamaro.postgresql/templates/postgresql.conf
@@ -497,7 +497,9 @@ default_with_oids           = {{'on' if postgresql_default_with_oids else 'off'}
 escape_string_warning       = {{'on' if postgresql_escape_string_warning else 'off'}}
 lo_compat_privileges        = {{'on' if postgresql_lo_compat_privileges else 'off'}}
 quote_all_identifiers       = {{'on' if postgresql_quote_all_identifiers else 'off'}}
+{% if postgresql_version < 10 %}
 sql_inheritance             = {{'on' if postgresql_sql_inheritance else 'off'}}
+{% endif %}
 standard_conforming_strings = {{'on' if postgresql_standard_conforming_strings else 'off'}}
 synchronize_seqscans        = {{'on' if postgresql_synchronize_seqscans else 'off'}}
 transform_null_equals       = {{'on' if postgresql_transform_null_equals else 'off'}}

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
 * PostgreSQL database server works for version > 10. See details from Issue #125.
Just checking the version and only including the problematic directive if it's less than 10.
