### PR TITLE
add cert_name flag for letsencrypt when cert names are not explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
   * Not working on OSX - macs don't read from /etc/profile.d/
   * Stops showing color if you `sudo su`
 
+## 2.5.2
+  * Always specify the letsencrypt cert_name so they are consistent
+
 ## 2.5.1
   * Fix os upgrades stat collection for ubuntu 20
 

--- a/README.md
+++ b/README.md
@@ -358,8 +358,6 @@ Installs redis on the server.
     # Change to * if you want tthis available everywhere.
     redis_bind: 127.0.0.1
 
-
-
 ## ruby-common
 
 Installs ruby on the machine.  YOu can set a version by picking off the download url and sha hash from ruby-lang.org

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -44,7 +44,7 @@
   - name: Run default
     when: le_ssl_certs is not defined
     become: true
-    command: "{{certbot_bin}} certonly --email {{letsencrypt_email}} --domains {{([server_name] + server_aliases) | join(',')}} --standalone --agree-tos --expand --non-interactive"
+    command: "{{certbot_bin}} certonly --email {{letsencrypt_email}} --domains {{([server_name] + server_aliases) | join(',')}} --cert-name {{server_name}} --standalone --agree-tos --expand --non-interactive"
 
   - name: Generate SSL Certificates
     become: true

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "2.5.1"
+  VERSION = "2.5.2"
 end


### PR DESCRIPTION
If this isn't present then it won't overwrite old certs and sometimes (unsure exactly when/why) letsencrypt will make directories like `/etc/letsencrypt/live/app.festbuddy.com-0002` which we don't want. 