### PR TITLE
Ansible errors, newrelic infra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## 2.5.3
   * Add a friendly error message if ansible is not installed
+  * Add new role to support New Relic One's infrastructure agent
 
 ## 2.5.2
   * Always specify the letsencrypt cert_name so they are consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
   * Not working on OSX - macs don't read from /etc/profile.d/
   * Stops showing color if you `sudo su`
 
+## 2.5.3
+  * Add a friendly error message if ansible is not installed
+
 ## 2.5.2
   * Always specify the letsencrypt cert_name so they are consistent
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,21 @@ Installs logrotate and lets you configure logs for automatic rotation.  Example 
 
 ## newrelic
 
+## newrelic-infra
+This role will install the next-gen "Newrelic One" infrastructure agent which can perform a few different functions for newrelic.  The previous "newrelic" role is deprecated. 
+
+Variables: 
+    # Required, the newrelic license key you get after signing up. 
+    newrelic_license: "longhashthingyougetfromnewrelichere" 
+    # Optional - send logs to newrelic one's log aggregator.
+    newrelic_logs:
+      - name: rails-production
+        path: /u/apps/blah/shared/log/production.log
+      - name: nginx-error
+        path: /var/log/nginx/error.log
+
+
+
 ## nginx-rails
 
 Configures nginx to look at localhost:9292 for the socket/backend connection.  If you need to do fancy stuff you should simply override this role

--- a/ansible/roles/newrelic-infra/defaults/main.yml
+++ b/ansible/roles/newrelic-infra/defaults/main.yml
@@ -1,0 +1,2 @@
+newrelic_license: ""
+newrelic_logs: []

--- a/ansible/roles/newrelic-infra/handlers/main.yml
+++ b/ansible/roles/newrelic-infra/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+  - name: Restart newrelic-infra
+    service:
+      name: newrelic-infra
+      state: restarted

--- a/ansible/roles/newrelic-infra/tasks/main.yml
+++ b/ansible/roles/newrelic-infra/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+  - name: Add New Relic apt key
+    apt_key:
+      url: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg 
+      state: present
+    become: true
+
+  - name: create license key
+    copy: 
+      dest: "/etc/newrelic-infra.yml"
+      content: |
+        license_key: {{newrelic_license}}
+
+  - name: Add New Relic apt repo
+    apt_repository:
+      repo: deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main
+      state: present
+    become: true
+
+  - name: Install New Relic server agent
+    apt:
+      pkg: newrelic-infra
+      state: present
+      update_cache: true
+    become: true
+
+  - name: Configure application log forwarding if enabled
+    when: "{{ newrelic_logs|length }}"
+    become: true
+    template: 
+      dest: "/etc/newrelic-infra/logging.d/subspace.yml"
+      src: logs.yml.j2
+    notify: Restart newrelic-infra

--- a/ansible/roles/newrelic-infra/templates/logs.yml.j2
+++ b/ansible/roles/newrelic-infra/templates/logs.yml.j2
@@ -1,0 +1,5 @@
+logs:
+{% for log in newrelic_logs %}
+  - name: {{log.name}}
+    file: {{log.path}}
+{% endfor %}

--- a/ansible/roles/newrelic/tasks/main.yml
+++ b/ansible/roles/newrelic/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+  - name: "Deprecation notice"
+    ansible.builtin.debug:
+      msg: The 'newrelic' role in subspace is deprecated. Please migration to Newrelic One and the 'newrelic-infra' role
+
   - name: Add New Relic apt repo
     apt_repository:
       repo: deb http://apt.newrelic.com/debian/ newrelic non-free

--- a/lib/subspace/cli.rb
+++ b/lib/subspace/cli.rb
@@ -24,6 +24,11 @@ class Subspace::Cli
     program :version, Subspace::VERSION
     program :description, 'Ansible-backed server provisioning tool for rails'
 
+    unless system("which ansible > /dev/null")
+      puts "*** Subspace depends on ansible being on your PATH. Please install it: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html"
+      exit 1
+    end
+
     command :init do |c|
       c.syntax = 'subspace init [vars]'
       c.summary = 'Run without options to initialize subspace.'

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "2.5.2"
+  VERSION = "2.5.3"
 end


### PR DESCRIPTION
## 2.5.3
  * Add a friendly error message if ansible is not installed
  * Add new role to support New Relic One's infrastructure agent