### PR TITLE
Add redis task to turn off protected mode

### DIFF
--- a/ansible/roles/redis/tasks/main.yml
+++ b/ansible/roles/redis/tasks/main.yml
@@ -32,6 +32,13 @@
       line: 'bind {{redis_bind}}'
       state: present
 
+  - name: Disable protected-mode
+    become: true
+    lineinfile:
+      name: /etc/redis/redis.conf
+      regexp: '^protected-mode yes'
+      line: 'protected-mode no'
+
   - name: restart redis
     become: true
     systemd:

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
 end


### PR DESCRIPTION
This caused on an incident on WIDA store after doing a full provision yesterday - we always want to make sure this gets set to no after removing distro-included redis and installing redis from apt.