### PR TITLE
Get the junk out of the os version string

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -306,7 +306,7 @@
       - maintenance
 
   - name: Grab OS version
-    shell: uname -rv
+    shell: . /etc/os-release; echo "$PRETTY_NAME"
     register: stats_os_version
     when: send_stats == true and stats_url is defined and stats_api_key is defined
     tags:


### PR DESCRIPTION
Make the OS Version string prettier for monthly reports and /software_versions page

<img width="434" alt="Screenshot 2024-06-11 at 11 52 56 AM" src="https://github.com/tenforwardconsulting/subspace/assets/651234/2147258c-38eb-4e92-ad2e-6d23691c879c">
