### PR TITLE
Pin tailscale to known good version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project attempts to follow [semantic versioning](https://semver.org/).
 
 ## Unreleased
 
+## 3.0.10
+ * Pin tailscale to known good version
+
 ## 3.0.9
  * Use pretty name for ubuntu version string
  * break system packages for psycopg2

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -17,6 +17,14 @@
       - maintenance
       - tailscale_reauth
 
+  - name: "Prevent tailscale from being upgraded"
+    dpkg_selections:
+      name: tailscale
+      selection: hold
+    tags:
+      - maintenance
+      - tailscale_reauth
+
   - name: "Install tailscale from apt"
     apt:
       name: tailscale=1.66.4

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -19,8 +19,9 @@
 
   - name: "Install tailscale from apt"
     apt:
-      name: tailscale
-      state: latest
+      name: tailscale=1.66.4
+      state: present
+      allow_downgrade: true
       update_cache: yes
     tags:
       - maintenance

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "3.0.9"
+  VERSION = "3.0.10"
 end


### PR DESCRIPTION
1.68.0 and higher are currently breaking ssh forwarding to github for deploy using capistrano