### PR TITLE
Fix tailscale unpinning/pinning; update changelog for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project attempts to follow [semantic versioning](https://semver.org/).
 
 ## Unreleased
 
+## 3.0.11
+  * Change tailscale pinning behavior to allow install, and then pin to specific version
+  * Fix psycopg2 break_system_packages to work across ubuntu/python versions
+
 ## 3.0.10
  * Pin tailscale to known good version
 

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -17,10 +17,10 @@
       - maintenance
       - tailscale_reauth
 
-  - name: "Prevent tailscale from being upgraded"
+  - name: "Allow tailscale to be installed"
     dpkg_selections:
       name: tailscale
-      selection: hold
+      selection: install
     tags:
       - maintenance
       - tailscale_reauth
@@ -31,6 +31,14 @@
       state: present
       allow_downgrade: true
       update_cache: yes
+    tags:
+      - maintenance
+      - tailscale_reauth
+
+  - name: "Prevent tailscale from being upgraded"
+    dpkg_selections:
+      name: tailscale
+      selection: hold
     tags:
       - maintenance
       - tailscale_reauth

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "3.0.10"
+  VERSION = "3.0.11"
 end


### PR DESCRIPTION
This worked on wida dev, so long as `tailscale` role executes before `common` role