### PR TITLE
Newrelic infra config to enable process metrics collection

### DIFF
--- a/ansible/roles/newrelic-infra/tasks/main.yml
+++ b/ansible/roles/newrelic-infra/tasks/main.yml
@@ -6,10 +6,9 @@
     become: true
 
   - name: create license key
-    copy:
+    template:
       dest: "/etc/newrelic-infra.yml"
-      content: |
-        license_key: {{newrelic_license}}
+      src: newrelic-infra.yml.j2
 
   - name: Add New Relic apt repo
     apt_repository:

--- a/ansible/roles/newrelic-infra/templates/newrelic-infra.yml.j2
+++ b/ansible/roles/newrelic-infra/templates/newrelic-infra.yml.j2
@@ -1,0 +1,2 @@
+license_key: {{newrelic_license}}
+enable_process_metrics: true

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "3.0.14"
+  VERSION = "3.0.15"
 end


### PR DESCRIPTION
We previously had this set in newrelic.yml (committed to individual projects), but this config actually needs to be set in `/etc/newrelic-infra.yml` on the server.