### PR TITLE
Add 'abbrev' gem as runtime dependency to fix ssh issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project attempts to follow [semantic versioning](https://semver.org/).
 
 ## Unreleased
 
+## 3.0.15
+  * Add 'abbrev' gem as runtime dependency to fix issue when doing `subspace ssh {hostname}`
+
 ## 3.0.14
   * Update oxenwagen template: remove profile, add final_snapshot_identifier
   * Change key to stat_type for client stats

--- a/lib/subspace/version.rb
+++ b/lib/subspace/version.rb
@@ -1,3 +1,3 @@
 module Subspace
-  VERSION = "3.0.14"
+  VERSION = "3.0.15"
 end

--- a/subspace.gemspec
+++ b/subspace.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency "commander", "~>4.2"
+  spec.add_runtime_dependency "abbrev", "~>0.1.2"
   spec.add_runtime_dependency "figaro", "~>1.0"
 end


### PR DESCRIPTION
this was blowing up when doing `subspace ssh {hostname}`